### PR TITLE
Fix gnomenu color on GNOME 3

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1215,12 +1215,12 @@ StScrollBar {
 .search-provider-icon:active, .search-provider-icon:checked,
 .list-search-result:active,
 .list-search-result:checked {
-	background-color: rgba(2,110,196,0.95); }
+	background-color: rgba(255,255,255,0.95);
 .search-provider-icon:focus, .search-provider-icon:selected, .search-provider-icon:hover,
 .list-search-result:focus,
 .list-search-result:selected,
 .list-search-result:hover {
-	background-color: rgba(2,110,196,0.95);
+	background-color: rgba(255,255,255,0.95);
 	background-gradient-direction: none;
 	transition-duration: 200ms;
 }
@@ -1235,7 +1235,7 @@ StScrollBar {
 .grid-search-result:active .overview-icon,
 .grid-search-result:checked .overview-icon {
 /* activities bottom-button selected-bg-color*/
-	background: rgba(2,110,196,0.9);
+	background: rgba(255,255,255,0.95);
 	border: 0;
 	box-shadow: inset 0 -2px 0 black;
 	border-radius: 0;
@@ -1922,7 +1922,7 @@ StScrollBar {
 	.screen-shield-notifications-container .notification,
 	.screen-shield-notifications-container .screen-shield-notification-source {
 		padding: 12px 6px;
-		border: 1px solid rgba(238, 238, 236, 0.75);
+		border: 1px solid rgba(255, 255, 255, 0.75);
 		background-color: rgba(0, 0, 0, 0.8);
 		color: #dbdee0;
 		border-radius: 0px; }


### PR DESCRIPTION
[Before](http://i.imgur.com/c4EY20U.png) and [After](http://i.imgur.com/X7ncPJe.png)
I'm trying to fix the color on the gnomenu (I would like to remove the blue and gray colors) and this seems to be working for me. However I'm not sure if it affects anything else. Feel free to have a look.