### PR TITLE
Fix Gnome Shell Volume OSD color:

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -474,20 +474,22 @@ StScrollBar {
 
 /* OSD */
 .osd-window {
-	text-align: center;
-	font-weight: bold;
-	spacing: 1em;
-	margin: 32px;
-	min-width: 64px;
-	min-height: 64px; }
-	.osd-window .osd-monitor-label {
-		font-size: 3em; }
-	.osd-window .level {
-		height: 0.6em;
-		border-radius: 0.3em;
-		background-color: rgba(0, 0, 0, 1);
-		color: white; }
-
+  text-align: center;
+  font-weight: bold;
+  spacing: 1em;
+  margin: 32px;
+  min-width: 64px;
+  min-height: 64px; }
+  .osd-window .osd-monitor-label {
+    font-size: 3em; }
+  .osd-window .level {
+    height: 0.6em;
+    -barlevel-height: 0.6em;
+    -barlevel-background-color: rgba(0, 0, 0, 1);
+    -barlevel-active-background-color: #eeeeec;
+    -barlevel-overdrive-color: #b2161d;
+    -barlevel-overdrive-separator-width: 0.2em; }
+    
 /* App Switcher (alt-tab) */
 .switcher-popup {
 	padding: 8px;


### PR DESCRIPTION
The level bar in the Gnome Shell Volume OSD shows as completely black. This fixes the issue by specifying appropriate barlevel parameters