### PR TITLE
Cinnamon - GWL - better distinguish focussed app from active apps. Visually match current window-list theme

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1727,17 +1727,25 @@ StScrollBar StButton#hhandle:focus {
   transition-duration: 100;
 }
 
-.grouped-window-list-item-box:hover,
-.grouped-window-list-item-box:focus {
+.grouped-window-list-item-box:hover {
+  color: #ffffff;
+  border-image: url("panel-assets/item-hover.svg") 4;
+  transition-duration: 100;
+}
+
+.grouped-window-list-item-box:active,
+.grouped-window-list-item-box:checked,
+.grouped-window-list-item-box:focus:hover,
+.grouped-window-list-item-box:active:hover,
+.grouped-window-list-item-box:checked:hover {
   color: #ffffff;
   border-image: url("panel-assets/item-active-hover.svg") 4;
   transition-duration: 100;
 }
 
-.grouped-window-list-item-box:active,
-.grouped-window-list-item-box:checked {
+.grouped-window-list-item-box:focus {
   color: #ffffff;
-  border-image: url("panel-assets/item-active.svg") 4;
+  border-image: url("panel-assets/item-active.svg") 8;
   transition-duration: 100;
 }
 


### PR DESCRIPTION
Hi, this is an interim suggestion to better distinguish the currently focused app in the grouped window list from other active apps. 

![screenshot-screen-2019-09-22-072913](https://user-images.githubusercontent.com/29017677/65383269-ed2be880-dd0a-11e9-92e8-ae6342a7f95c.png)
