### PR TITLE
Fix missing margin for search box in main menu

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1616,6 +1616,7 @@ StScrollBar StButton#hhandle:focus {
 }
 
 #menu-search-entry {
+  margin-right: 10px;
   padding: 10px 8px;
   color: rgba(255, 255, 255, 0.7);
   font-size: 10pt;


### PR DESCRIPTION
Patch tested with Cinnamon version `5.15.0-53-generic` on `Linux Mint 21 Cinnamon`

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/4741199/202388549-efdbc3c7-28a3-417f-b874-5fa9b419383c.png) | ![after](https://user-images.githubusercontent.com/4741199/202388577-039e4041-81e1-41e1-ad1f-b3a2a31bb385.png) |
